### PR TITLE
replace subscription with query polling, fix routing to dashboard

### DIFF
--- a/client/components/Login.tsx
+++ b/client/components/Login.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useContext, useEffect } from 'react'
+import Router from 'next/router'
 import { useLazyQuery } from '@apollo/client'
 import {
   Grid,
@@ -85,7 +86,7 @@ export default function Login(props: Props) {
     if (loginResult) {
       appContext.setIsLoggedIn(true)
       gaService.loginSuccessEvent()
-      window.location.replace('/dashboard')
+      Router.push('/dashboard')
     } else {
       onError()
     }

--- a/client/pages/dashboard.tsx
+++ b/client/pages/dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useContext, useState } from 'react'
 import Router from 'next/router'
-import { useMutation, useSubscription } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client'
 import { Grid, Paper, Typography, TextField, Button, CircularProgress, Collapse } from '@material-ui/core'
 import { Skeleton } from '@material-ui/lab'
 import { makeStyles } from '@material-ui/core/styles'
@@ -75,7 +75,10 @@ function Dashboard() {
   const classes = useStyles()
   const appContext = useContext(AppContext)
 
-  const { error, data } = useSubscription(graphqlService.SUBSCRIBE_CURRENT_USER, { variables: {} })
+  const { error, data } = useQuery(graphqlService.CURRENT_USER, { 
+    variables: {},
+    pollInterval: 500,
+  })
 
   const handleCreateHolding = () => {
     setCreateHoldingLoading(true)

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useContext } from 'react'
+import Router from 'next/router'
 import { withApollo } from 'components/withApollo'
 import { initApolloClient } from 'services/apolloService'
 import { AppContext } from 'context/AppContext'
@@ -42,7 +43,7 @@ function Home() {
 
   useEffect(() => {
     if (appContext.isLoggedIn) {
-      window.location.replace('/dashboard')
+      Router.push('/dashboard')
     }
   }, [appContext])
 

--- a/client/services/apolloService.ts
+++ b/client/services/apolloService.ts
@@ -1,42 +1,17 @@
-import { ApolloClient, InMemoryCache, ApolloLink, HttpLink, split, OperationVariables } from '@apollo/client'
-import { WebSocketLink } from '@apollo/link-ws'
+import { ApolloClient, InMemoryCache, ApolloLink, HttpLink } from '@apollo/client'
 import { onError } from '@apollo/link-error'
 import { setContext } from '@apollo/link-context'
-import { getMainDefinition } from 'apollo-utilities'
-import { API_URL, WS_URL } from 'helpers/constants'
-import { userService } from 'services/userService'
+import { API_URL, TOKEN } from 'helpers/constants'
+import Cookie from 'js-cookie'
 
 global.fetch = require('node-fetch')
 
 let globalApolloClient: any = null
 
-const wsLinkwithoutAuth = () =>
-  new WebSocketLink({
-    uri: WS_URL,
-    options: {
-      reconnect: true,
-    },
-  })
-
-const wsLinkwithAuth = (token: string) =>
-  new WebSocketLink({
-    uri: WS_URL,
-    options: {
-      reconnect: true,
-      connectionParams: {
-        Authorization: `Bearer ${token}`,
-      },
-    },
-  })
-
 function createIsomorphLink() {
   return new HttpLink({
     uri: API_URL,
   })
-}
-
-function createWebSocketLink() {
-  return userService.token ? wsLinkwithAuth(userService.token) : wsLinkwithoutAuth()
 }
 
 const errorLink = onError(({ networkError, graphQLErrors }) => {
@@ -51,13 +26,12 @@ const errorLink = onError(({ networkError, graphQLErrors }) => {
 })
 
 const authLink = setContext((_, { headers }) => {
-  const token = userService.token
-  const authorization = token ? `Bearer ${token}` : null
+  const token = Cookie.getJSON(TOKEN)
   return token
     ? {
         headers: {
           ...headers,
-          authorization,
+          authorization: `Bearer ${token}`,
         },
       }
     : {
@@ -71,20 +45,8 @@ const httpLink = ApolloLink.from([errorLink, authLink, createIsomorphLink()])
 
 export function createApolloClient(initialState = {}) {
   const ssrMode = typeof window === 'undefined'
+  const link = httpLink
   const cache = new InMemoryCache().restore(initialState)
-
-  const link = ssrMode
-    ? httpLink
-    : process.browser
-    ? split(
-        ({ query }: any) => {
-          const { kind, operation }: OperationVariables = getMainDefinition(query)
-          return kind === 'OperationDefinition' && operation === 'subscription'
-        },
-        createWebSocketLink(),
-        httpLink
-      )
-    : httpLink
 
   return new ApolloClient({
     ssrMode,


### PR DESCRIPTION
Use query polling over graphql subscriptions for now.

Revisit subscriptions and live queries after migrating to AWS - would be too much effort down a path that will likely become irrelevant.